### PR TITLE
fix: ec2 user script

### DIFF
--- a/infra/scripts/install-mysql.sh
+++ b/infra/scripts/install-mysql.sh
@@ -5,4 +5,4 @@ export PASSWORD=$(aws secretsmanager get-secret-value --secret-id "$1" --region 
 sudo mkdir -p /home/ec2-user/init
 sudo chmod -R 777 /home/ec2-user/init
 echo "GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* to admin@'%';" >> /home/ec2-user/init/grants.sql
-sudo docker run -d -p 3306:3306 --name db -e MYSQL_USER=admin -e MYSQL_DATABASE=gaming -e MYSQL_PASSWORD="$PASSWORD" -e MYSQL_ROOT_PASSWORD="$PASSWORD" -v /home/ec2-user/init:/docker-entrypoint-initdb.d: mysql:8
+sudo docker run -d -p 3306:3306 --name db -e MYSQL_USER=admin -e MYSQL_DATABASE=gaming -e MYSQL_PASSWORD="$PASSWORD" -e MYSQL_ROOT_PASSWORD="$PASSWORD" -v /home/ec2-user/init:/docker-entrypoint-initdb.d mysql:8


### PR DESCRIPTION
The docker container wasn't starting because there is an extra colon after mounting a volume.

This leads to Flink not being able to connect to the MySQL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

PS: If you accept this change, please also make sure it gets propagated to all the branches.
