### PR TITLE
fix: python build

### DIFF
--- a/infra/lib/constructs/datagen/datagen-players.ts
+++ b/infra/lib/constructs/datagen/datagen-players.ts
@@ -27,7 +27,15 @@ export class DatagenPlayers extends Construct {
         const dataGenFn = new Function(this, 'fn', {
             runtime: Runtime.PYTHON_3_9,
             handler: 'app.lambda_handler',
-            code: Code.fromAsset(playersFnFolder),
+            code: Code.fromAsset(playersFnFolder, {
+              bundling: {
+                image: Runtime.PYTHON_3_9.bundlingImage,
+                command: [
+                  'bash', '-c',
+                  'pip install -r requirements.txt -t /asset-output && cp -au . /asset-output'
+                ],
+              },
+            }),
             timeout: Duration.minutes(1),
             vpc: props.vpc,
             vpcSubnets: {subnetType: SubnetType.PRIVATE_WITH_EGRESS},


### PR DESCRIPTION
Requirements aren't automatically packaged when using CDK. Adding the build step that installs the requirements and packages the lambda code in CDK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

More here: https://docs.aws.amazon.com/cdk/api/v1/docs/aws-lambda-readme.html#bundling-asset-code